### PR TITLE
README: describe setting known_hosts, add remote server steps

### DIFF
--- a/debian/sidedoor.default
+++ b/debian/sidedoor.default
@@ -7,4 +7,5 @@
 #OPTIONS='-R 8022:localhost:22'
 
 # Remote SSH server to connect to, i.e., [user@]hostname.
+# Example: REMOTE_SERVER=sidedoor-portfw@example.com
 REMOTE_SERVER=


### PR DESCRIPTION
Just having gone through the process of installing, configuring and debugging sidedoor, this commits tries to make a few spots in the README clearer to make it easier for the next person.

It also mentions that you should set "ClientAliveInterval 30" on the server side. This is a footgun that I hit when testing sidedoor: Without it, a hung ssh session can block the port and the remote server for a long time (days? hours?), making the tunnel unusable.

Fixes https://github.com/daradib/sidedoor/issues/3