### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,9 @@ sidedoor (0.2.1-2) UNRELEASED; urgency=medium
   * Set debhelper-compat version in Build-Depends.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Remove constraints unnecessary since buster (oldstable):
+    + sidedoor: Drop versioned constraint on lsb-base (>= 3.0-6) in Depends.
+    + Remove 1 maintscript entries from 1 files.
 
  -- Dara Adib <daradib@ocf.berkeley.edu>  Sat, 18 Jul 2020 23:03:52 -0400
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Rules-Requires-Root: no
 
 Package: sidedoor
 Architecture: all
-Depends: adduser, lsb-base (>= 3.0-6), openssh-client, ${misc:Depends}
+Depends: adduser, lsb-base, openssh-client, ${misc:Depends}
 Recommends: openssh-server
 Suggests: sidedoor-sudo
 Description: SSH connection daemon

--- a/debian/sidedoor-sudo.maintscript
+++ b/debian/sidedoor-sudo.maintscript
@@ -1,2 +1,0 @@
-# sidedoor-sudo 0.1.1-1 shipped a bad filename.
-rm_conffile /etc/sudoers.d/sudoers 0.2~


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

File lists identical (after any substitutions)
### Control files of package sidedoor: lines which differ (wdiff format)
* Depends: adduser, [-lsb-base (>= 3.0-6),-] {+lsb-base,+} openssh-client

No differences were encountered between the control files of package \*\*sidedoor-sudo\*\*

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6af6735c-9e61-4be1-adb2-44093090408a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6af6735c-9e61-4be1-adb2-44093090408a/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/sidedoor/6af6735c-9e61-4be1-adb2-44093090408a.